### PR TITLE
deploy to now

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,9 @@
 language: node_js
 node_js:
 - node
-
+deploy:
+  script: scripts/deploy.sh
+  provider: script
+  skip_cleanup: true
+  on:
+    branch: master

--- a/package.json
+++ b/package.json
@@ -21,5 +21,14 @@
   "keywords": [
     "node",
     "server"
-  ]
+  ],
+  "now": {
+    "alias": "first-timers-bot",
+    "env": {
+      "APP_ID": "@app-id",
+      "NODE_ENV": "production",
+      "PRIVATE_KEY": "@private-key",
+      "WEBHOOK_SECRET": "@webhook-secret"
+    }
+  }
 }

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -1,0 +1,8 @@
+#!/bin/sh
+
+# https://github.com/zeit/now-cli/issues/817
+now="npx now@7.1.1 --token=$NOW_TOKEN"
+
+$now --public
+$now alias
+$now rm --safe --yes wip-bot


### PR DESCRIPTION
Here are my notes on how to make it work, it’s not as simple as I initially thought :)

1. Create a new now account
Make a dedicated account for each open source application you want to deploy, as the free account is limited to 3 instances only. Sign up/in at https://zeit.co/login (leave page open, click the link on the email, go back to the tab where you entered your email).
2. create a new token at https://zeit.co/account/tokens
3. Set the token in Travis’ repository settings as `NOW_TOKEN`
4. Now use the terminal so set [secrets](https://zeit.co/blog/environment-variables-secrets) in your now account
- now secret add app-id <ID of your app>
- now secret add webhook-secret <secret of your app>
- now secret add private-key <base64 encoded private-key.pem>
To encode the private key from GitHub, run this command in the folder that you downloaded `private-key.pem` to: `cat private-key.pem | base64 --input - | pbcopy`. The base64 encoded private-key.pem is now in your clipboard, you can paste it into your terminal after `now secret add private-key`
5. In your `package.json` file, create a new key “now”:
```
  "now": {
    "alias": “<your app name>“,
    "env": {
      "APP_ID": "@app-id",
      "NODE_ENV": "production",
      "PRIVATE_KEY": "@private-key",
      "WEBHOOK_SECRET": "@webhook-secret"
    }
  }
```
`<your app name>` will end up as the sodomain of <app name>.now.sh.
6. Create a file `scripts/deploy.sh` with this content
```
#!/bin/sh
now="npx now@7.1.1 --token=$NOW_TOKEN"
$now --public
$now alias
$now rm --safe --yes wip-bot
```
7. Make it executable with `chmod +x scripts/deploy.sh`
8. Add to your `.travis.yml` file
```
deploy:
  script: scripts/deploy.sh
  provider: script
  skip_cleanup: true
  on:
    branch: master
```
9. That’s it :) When tests pass on master, your app will be deployed to now automagically

So after you merge this PR, watch the travis build logs at travis-ci.org/hoodiehq/first-timers-bot and wait for the deploy step. If all goes well, you should see the logs of the newly deployed version at https://first-timers-bot.now.sh/_logs (look for the timestamps) 🙏 

Once that looks all good, you can change the `Webhook UR` URL to https://first-timers-bot.now.sh.

We can add deploy to Glitch separately in another PR

closes #79 