### PR TITLE
custom start command for now

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "main": "server.js",
   "scripts": {
     "start": "probot run ./server.js",
+    "now-start": "PRIVATE_KEY=$(echo $PRIVATE_KEY | base64 -d) npm start",
     "test": "standard"
   },
   "dependencies": {


### PR DESCRIPTION
The private key is base64 encoded, we have to decode it before starting the app. This fixes it