### PR TITLE
More robust deploy script

### DIFF
--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -1,8 +1,12 @@
 #!/bin/sh
 
-# https://github.com/zeit/now-cli/issues/817
-now="npx now@7.1.1 --token=$NOW_TOKEN"
+now="npx now --debug --token=$NOW_TOKEN"
 
-$now --public
-$now alias
+echo "$ now rm --safe --yes first-timers-bot"
 $now rm --safe --yes first-timers-bot
+
+echo "$ now --public"
+$now --public
+
+echo "$ now alias"
+$now alias


### PR DESCRIPTION
It keeps the latest two deploys around instead of just one, so if a request is being handled during the deploy it will still work and not killed off while processing it