### PR TITLE
Attempt to correct linked file regEx in branchUrl

### DIFF
--- a/lib/get-commit.js
+++ b/lib/get-commit.js
@@ -11,7 +11,7 @@ function getCommit (state) {
 
     .then(function (result) {
       const {filename, patch, blob_url: blobUrl} = result.data.files[0]
-      var branchUrl = blobUrl.replace(/(?:blob)(.+)(?=\/)/g, 'blob/' + state.repoDefaultBranch)
+      var branchUrl = blobUrl.replace(/(?:blob\/)(\w+)/g, 'blob/' + state.repoDefaultBranch)
 
       state.commit = {
         message: result.data.commit.message,


### PR DESCRIPTION
Hi, I /think/ this is correct:

`(.+)` is changed to `(\w+)` and the slash is moved inside the "blob" bit. I tested and it correctly addresses the issue in #189. It had been grabbing all of `blob/branch-name/path/to/file.rb` and replacing, instead of just `blob/branch-name`. 

...but am not sure of branch name conventions. Will `(\w+)` correctly grab any branch name? 