### PR TITLE
Test + fix for get-commit-test.js to return correct path in branchUrl

### DIFF
--- a/lib/get-commit.js
+++ b/lib/get-commit.js
@@ -11,7 +11,7 @@ function getCommit (state) {
 
     .then(function (result) {
       const {filename, patch, blob_url: blobUrl} = result.data.files[0]
-      var branchUrl = blobUrl.replace(/(?:blob\/)(\w+)/g, 'blob/' + state.repoDefaultBranch)
+      var branchUrl = blobUrl.replace(/\/blob\/[^/]+/, 'blob/' + state.repoDefaultBranch)
 
       state.commit = {
         message: result.data.commit.message,

--- a/lib/get-commit.js
+++ b/lib/get-commit.js
@@ -11,7 +11,7 @@ function getCommit (state) {
 
     .then(function (result) {
       const {filename, patch, blob_url: blobUrl} = result.data.files[0]
-      var branchUrl = blobUrl.replace(/\/blob\/[^/]+/, 'blob/' + state.repoDefaultBranch)
+      var branchUrl = blobUrl.replace(/\/blob\/[^/]+/, '/blob/' + state.repoDefaultBranch)
 
       state.commit = {
         message: result.data.commit.message,

--- a/lib/get-commit.js
+++ b/lib/get-commit.js
@@ -11,7 +11,7 @@ function getCommit (state) {
 
     .then(function (result) {
       const {filename, patch, blob_url: blobUrl} = result.data.files[0]
-      var branchUrl = blobUrl.replace(/(?:blob)(.+)(?=\/)/g, 'blob/' + state.repoDefaultBranch)
+      var branchUrl = blobUrl.replace(/(?:blob\/)(\w+)/g, 'blob/' + state.repoDefaultBranch)
 
       state.commit = {
         message: result.data.commit.message,

--- a/test/unit/get-commit-test.js
+++ b/test/unit/get-commit-test.js
@@ -25,7 +25,7 @@ test('get commit request succeeds', t => {
       files: [{
         filename: 'filename',
         patch: 'patch',
-        blob_url: 'https://github.com/Techforchange/first-timers-test/blob/f00ecb1bbffe515500558568ae0b176d2a1defe8/docs/README.md'
+        blob_url: 'https://github.com/Techforchange/first-timers-test/blob/f00ecb1bbffe515500558568ae0b176d2a1defe8/README.md'
       }],
       commit: {
         message: 'message'

--- a/test/unit/get-commit-test.js
+++ b/test/unit/get-commit-test.js
@@ -25,7 +25,7 @@ test('get commit request succeeds', t => {
       files: [{
         filename: 'filename',
         patch: 'patch',
-        blob_url: 'https://github.com/Techforchange/first-timers-test/blob/f00ecb1bbffe515500558568ae0b176d2a1defe8/README.md'
+        blob_url: 'https://github.com/Techforchange/first-timers-test/blob/f00ecb1bbffe515500558568ae0b176d2a1defe8/docs/README.md'
       }],
       commit: {
         message: 'message'

--- a/test/unit/get-commit-test.js
+++ b/test/unit/get-commit-test.js
@@ -47,7 +47,7 @@ test('get commit request succeeds', t => {
       t.is(state.commit.message, 'message')
       t.is(state.commit.filename, 'filename')
       t.is(state.commit.patch, 'patch')
-      t.is(state.commit.branchUrl, 'https://github.com/Techforchange/first-timers-test/blob/defaultBranch/README.md')
+      t.is(state.commit.branchUrl, 'https://github.com/Techforchange/first-timers-test/blob/defaultBranch/docs/README.md')
       t.is(state.commit.authorLogin, 'username')
 
       simple.restore()

--- a/test/unit/get-commit-test.js
+++ b/test/unit/get-commit-test.js
@@ -25,7 +25,7 @@ test('get commit request succeeds', t => {
       files: [{
         filename: 'filename',
         patch: 'patch',
-        blob_url: 'https://github.com/Techforchange/first-timers-test/blob/f00ecb1bbffe515500558568ae0b176d2a1defe8/README.md'
+        blob_url: 'https://github.com/Techforchange/first-timers-test/blob/f00ecb1bbffe515500558568ae0b176d2a1defe8/docs/README.md'
       }],
       commit: {
         message: 'message'
@@ -44,7 +44,7 @@ test('get commit request succeeds', t => {
       t.is(state.commit.message, 'message')
       t.is(state.commit.filename, 'filename')
       t.is(state.commit.patch, 'patch')
-      t.is(state.commit.branchUrl, 'https://github.com/Techforchange/first-timers-test/blob/defaultBranch/README.md')
+      t.is(state.commit.branchUrl, 'https://github.com/Techforchange/first-timers-test/blob/defaultBranch/docs/README.md')
 
       simple.restore()
       t.end()


### PR DESCRIPTION
This test highlights an issue which I have written a fix for; adding the fix as a next step. Thanks!

`(.+)` is changed to `(\w+)` and the slash is moved inside the "blob" bit. I tested and it correctly addresses the issue in #189. It had been grabbing all of `blob/branch-name/path/to/file.rb` and replacing, instead of just `blob/branch-name`. 
