### PR TITLE
.repos.getCommit() now expects `ref` instead of `sha`

### DIFF
--- a/lib/get-commit.js
+++ b/lib/get-commit.js
@@ -6,7 +6,7 @@ function getCommit (state) {
   return state.api.repos.getCommit({
     owner: state.owner,
     repo: state.installRepo,
-    sha: state.sha
+    ref: state.sha
   })
 
     .then(function (result) {

--- a/test/unit/get-commit-test.js
+++ b/test/unit/get-commit-test.js
@@ -43,7 +43,7 @@ test('get commit request succeeds', t => {
     api.repos.getCommit.lastCall.arg
       t.is(getCommitArgs.owner, 'owner')
       t.is(getCommitArgs.repo, 'installRepo')
-      t.is(getCommitArgs.sha, 'sha')
+      t.is(getCommitArgs.ref, 'sha')
       t.is(state.commit.message, 'message')
       t.is(state.commit.filename, 'filename')
       t.is(state.commit.patch, 'patch')


### PR DESCRIPTION
That should fix #233 @jywarren